### PR TITLE
Remove init(coder:) from viewController template

### DIFF
--- a/lib/ccios/templates/view_controller.mustache
+++ b/lib/ccios/templates/view_controller.mustache
@@ -12,15 +12,6 @@ import UIKit
 class {{name}}ViewController: SharedViewController, {{name}}ViewContract {
     var presenter: {{name}}Presenter?
 
-    init() {
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    @available(*, unavailable)
-    required init?(coder decoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         presenter?.start()


### PR DESCRIPTION
Since I added `@available(*, unavailable)` to SharedViewController in the templater there is no need to add it here in the viewController template.
As a bonus it make the tool more friendly to people who use storyboards