### PR TITLE
Import Core in repo implementations

### DIFF
--- a/lib/ccios/templates/repository_implementation.mustache
+++ b/lib/ccios/templates/repository_implementation.mustache
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import Core
 
 public class {{name}}RepositoryImplementation: {{name}}Repository {
 

--- a/test/templates/repository_implementation.swift
+++ b/test/templates/repository_implementation.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import Core
 
 public class TestRepositoryImplementation: TestRepository {
 


### PR DESCRIPTION
This is required since the repo protocol are now defined in the Core framework.
I admit that this change would made ccios no longer fabernovel-agnostic ^^ 
So feel free to reject the PR if you prefer to make no assumption about the projets using CCIOS