### PR TITLE
Do not provide a name to groups in a project with folder references

### DIFF
--- a/lib/ccios/file_creator.rb
+++ b/lib/ccios/file_creator.rb
@@ -2,6 +2,18 @@ require_relative 'code_templater'
 require 'fileutils'
 require 'logger'
 
+class Xcodeproj::Project::Object::PBXGroup
+
+  def pf_new_group(associate_path_to_group:, name:, path:)
+    # When using "Group with folder" we only provide a path
+    # When using "Group without folder" we only provide a name
+    new_group(
+      associate_path_to_group ? nil : name,
+      associate_path_to_group ? path : nil
+    )
+  end
+end
+
 class FileCreator
 
   def self.logger

--- a/lib/ccios/interactor_generator.rb
+++ b/lib/ccios/interactor_generator.rb
@@ -16,7 +16,11 @@ class InteractorGenerator
 
     raise "[Error] Group #{new_group_name} already exists in #{app_group.display_name}" if interactor_group[new_group_name]
     new_group_path = File.join(interactor_group.real_path, new_group_name)
-    new_group = interactor_group.new_group(new_group_name, associate_path_to_group ? new_group_path : nil)
+    new_group = interactor_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: new_group_name,
+      path: new_group_path
+    )
 
     file_creator = FileCreator.new(options)
     target = @parser.core_target

--- a/lib/ccios/presenter_generator.rb
+++ b/lib/ccios/presenter_generator.rb
@@ -15,22 +15,46 @@ class PresenterGenerator
 
     raise "[Error] Group #{presenter_name} already exists in #{app_group.display_name}" if app_group[presenter_name]
     new_group_path = File.join(app_group.real_path, presenter_name)
-    new_group = app_group.new_group(presenter_name, associate_path_to_group ? new_group_path : nil)
+    new_group = app_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: presenter_name,
+      path: new_group_path
+    )
 
     ui_group_path = File.join(new_group_path, "UI")
-    ui_group = new_group.new_group("UI", associate_path_to_group ? ui_group_path : nil)
+    ui_group = new_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: "UI",
+      path: ui_group_path
+    )
 
     view_group_path = File.join(ui_group_path, "View")
-    view_group = ui_group.new_group("View", associate_path_to_group ? view_group_path : nil)
+    view_group = ui_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: "View",
+      path: view_group_path
+    )
 
     view_controller_group_path = File.join(ui_group_path, "ViewController")
-    view_controller_group = ui_group.new_group("ViewController", associate_path_to_group ? view_controller_group_path : nil)
+    view_controller_group = ui_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: "ViewController",
+      path: view_controller_group_path
+    )
 
     presenter_group_path = File.join(new_group_path, "Presenter")
-    presenter_group = new_group.new_group("Presenter", associate_path_to_group ? presenter_group_path : nil)
+    presenter_group = new_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: "Presenter",
+      path: presenter_group_path
+    )
 
     model_group_path = File.join(new_group_path, "Model")
-    model_group = new_group.new_group("Model", associate_path_to_group ? model_group_path : nil)
+    model_group = new_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: "Model",
+      path: model_group_path
+    )
 
     file_creator = FileCreator.new(options)
     target = @parser.app_target

--- a/lib/ccios/repository_generator.rb
+++ b/lib/ccios/repository_generator.rb
@@ -15,12 +15,20 @@ class RepositoryGenerator
     raise "[Error] Group #{repository_name} already exists in #{core_group.display_name}" if core_group[repository_name]
     associate_path_to_group = !core_group.path.nil?
     core_data_new_group_path = File.join(core_group.real_path, repository_name)
-    core_data_new_group = core_group.new_group(repository_name, associate_path_to_group ? core_data_new_group_path : nil)
+    core_data_new_group = core_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: repository_name,
+      path: core_data_new_group_path
+    )
 
     raise "[Error] Group #{repository_name} already exists in #{data_group.display_name}" if data_group[repository_name]
     associate_path_to_group = !data_group.path.nil?
     data_new_group_path = File.join(data_group.real_path, repository_name)
-    data_new_group = data_group.new_group(repository_name, associate_path_to_group ? data_new_group_path : nil)
+    data_new_group = data_group.pf_new_group(
+      associate_path_to_group: associate_path_to_group,
+      name: repository_name,
+      path: data_new_group_path
+    )
 
     file_creator = FileCreator.new(options)
     core_target = @parser.core_target

--- a/test/test_xcodeproj_with_folder.rb
+++ b/test/test_xcodeproj_with_folder.rb
@@ -102,12 +102,24 @@ class XcodeProjWithFolderTest < Minitest::Test
       generator = generator_class.new(parser, config)
       generator.generate(name)
 
+      assert_group_and_subgroups_have_no_name(group)
+
       expected_files.each do |file_name|
         expected_path = File.join(@test_dir, source_path, file_name)
         assert File.exist?(expected_path), "File #{expected_path} does not exist"
         refute_nil group[file_name]
       end
     end
+  end
+
+  def assert_group_and_subgroups_have_no_name(group)
+    subgroups = group.children.select { |o| o.isa == "PBXGroup" }
+    subgroups.each { |subgroup|
+      assert_nil subgroup.name
+      refute_nil subgroup.path
+      # recursively test children
+      assert_group_and_subgroups_have_no_name subgroup
+    }
   end
 
   def set_up_project_in_temporary_directory

--- a/test/test_xcodeproj_without_folder.rb
+++ b/test/test_xcodeproj_without_folder.rb
@@ -102,6 +102,8 @@ class XcodeProjWithoutFolderTest < Minitest::Test
       generator = generator_class.new(parser, config)
       generator.generate(name)
 
+      assert_group_and_subgroups_have_no_path(group)
+
       expected_files.each do |file_name|
         base_name = File.basename(file_name)
         expected_path = File.join(@test_dir, source_path, base_name)
@@ -110,6 +112,16 @@ class XcodeProjWithoutFolderTest < Minitest::Test
         refute_nil group[file_name], "Group #{file_name} should exist"
       end
     end
+  end
+
+  def assert_group_and_subgroups_have_no_path(group)
+    subgroups = group.children.select { |o| o.isa == "PBXGroup" }
+    subgroups.each { |subgroup|
+      refute_nil subgroup.name
+      assert_nil subgroup.path
+      # recursively test children
+      assert_group_and_subgroups_have_no_path subgroup
+    }
   end
 
   def set_up_project_in_temporary_directory


### PR DESCRIPTION
Otherwise, xcode will remove the name from the group everytime we create new files in the project.