### PR TITLE
Remove extra suffix if present

### DIFF
--- a/lib/ccios/coordinator_generator.rb
+++ b/lib/ccios/coordinator_generator.rb
@@ -12,6 +12,7 @@ class CoordinatorGenerator
     coordinator_group = @parser.coordinator_group
     file_creator = FileCreator.new(options)
     target = @parser.app_target
+    coordinator_name = coordinator_name.gsub("Coordinator", "")
     file_creator.create_file(coordinator_name, 'Coordinator', coordinator_group, target)
   end
 end

--- a/lib/ccios/interactor_generator.rb
+++ b/lib/ccios/interactor_generator.rb
@@ -10,6 +10,7 @@ class InteractorGenerator
 
   def generate(interactor_name, options = {})
     interactor_group = @parser.interactor_group
+    interactor_name = interactor_name.gsub("Interactor", "")
     new_group_name = "#{interactor_name}Interactor"
 
     associate_path_to_group = !interactor_group.path.nil?

--- a/lib/ccios/presenter_generator.rb
+++ b/lib/ccios/presenter_generator.rb
@@ -10,7 +10,7 @@ class PresenterGenerator
 
   def generate(presenter_name, options = {})
     app_group = @parser.presenter_group
-
+    presenter_name = presenter_name.gsub("Presenter", "")
     associate_path_to_group = !app_group.path.nil?
 
     raise "[Error] Group #{presenter_name} already exists in #{app_group.display_name}" if app_group[presenter_name]

--- a/lib/ccios/repository_generator.rb
+++ b/lib/ccios/repository_generator.rb
@@ -11,6 +11,7 @@ class RepositoryGenerator
   def generate(repository_name, options = {})
     core_group = @parser.repository_core_group
     data_group = @parser.repository_data_group
+    repository_name = repository_name.gsub("Repository", "")
 
     raise "[Error] Group #{repository_name} already exists in #{core_group.display_name}" if core_group[repository_name]
     associate_path_to_group = !core_group.path.nil?

--- a/test/test_xcodeproj_with_folder.rb
+++ b/test/test_xcodeproj_with_folder.rb
@@ -19,64 +19,84 @@ class XcodeProjWithFolderTest < Minitest::Test
     FileUtils.remove_entry(@test_dir)
   end
 
-  def test_coordinator_folders
-    generate_and_assert(
-      xcodeproj_group: Proc.new { |parser| parser.coordinator_group },
-      source_path: "MyProject/GroupWithFolder/Coordinator",
-      generator_class: CoordinatorGenerator,
-      name: "Cotest",
-      expected_files: ["CotestCoordinator.swift"]
-    )
+  [false, true].each do |use_suffix|
+    method_suffix = use_suffix ? "_with_suffix" : ""
+    name = use_suffix ? "CotestCoordinator" : "Cotest"
+    define_method "test_coordinator_folders#{method_suffix}" do
+      generate_and_assert(
+        xcodeproj_group: Proc.new { |parser| parser.coordinator_group },
+        source_path: "MyProject/GroupWithFolder/Coordinator",
+        generator_class: CoordinatorGenerator,
+        name: name,
+        expected_files: ["CotestCoordinator.swift"]
+      )
+    end
   end
 
-  def test_interactor_folders
-    generate_and_assert(
-      xcodeproj_group: Proc.new { |parser| parser.interactor_group },
-      source_path: "MyProject/GroupWithFolder/Interactor",
-      generator_class: InteractorGenerator,
-      name: "Intest",
-      expected_files: [
-        "IntestInteractor/IntestInteractor.swift",
-        "IntestInteractor/IntestInteractorImplementation.swift"
-      ]
-    )
+  [false, true].each do |use_suffix|
+    method_suffix = use_suffix ? "_with_suffix" : ""
+    name = use_suffix ? "IntestInteractor" : "Intest"
+    define_method "test_interactor_folders#{method_suffix}" do
+      generate_and_assert(
+        xcodeproj_group: Proc.new { |parser| parser.interactor_group },
+        source_path: "MyProject/GroupWithFolder/Interactor",
+        generator_class: InteractorGenerator,
+        name: name,
+        expected_files: [
+          "IntestInteractor/IntestInteractor.swift",
+          "IntestInteractor/IntestInteractorImplementation.swift"
+        ]
+      )
+    end
   end
 
-  def test_presenter_folders
-    generate_and_assert(
-      xcodeproj_group: Proc.new { |parser| parser.presenter_group },
-      source_path: "MyProject/GroupWithFolder/Presenter",
-      generator_class: PresenterGenerator,
-      name: "Pretest",
-      expected_files: [
-        "Pretest/UI/View",
-        "Pretest/UI/ViewController/PretestViewController.swift",
-        "Pretest/UI/PretestViewContract.swift",
-        "Pretest/Presenter/PretestPresenter.swift",
-        "Pretest/Presenter/PretestPresenterImplementation.swift",
-        "Pretest/Model"
-      ]
-    )
+  [false, true].each do |use_suffix|
+    method_suffix = use_suffix ? "_with_suffix" : ""
+    name = use_suffix ? "PretestPresenter" : "Pretest"
+    define_method "test_presenter_folders#{method_suffix}" do
+      generate_and_assert(
+        xcodeproj_group: Proc.new { |parser| parser.presenter_group },
+        source_path: "MyProject/GroupWithFolder/Presenter",
+        generator_class: PresenterGenerator,
+        name: name,
+        expected_files: [
+          "Pretest/UI/View",
+          "Pretest/UI/ViewController/PretestViewController.swift",
+          "Pretest/UI/PretestViewContract.swift",
+          "Pretest/Presenter/PretestPresenter.swift",
+          "Pretest/Presenter/PretestPresenterImplementation.swift",
+          "Pretest/Model"
+        ]
+      )
+    end
   end
 
-  def test_repository_data_folders
-    generate_and_assert(
-      xcodeproj_group: Proc.new { |parser| parser.repository_data_group },
-      source_path: "MyProject/GroupWithFolder/Repository",
-      generator_class: RepositoryGenerator,
-      name: "Retest",
-      expected_files: ["Retest/RetestRepositoryImplementation.swift"]
-    )
+  [false, true].each do |use_suffix|
+    method_suffix = use_suffix ? "_with_suffix" : ""
+    name = use_suffix ? "RetestRepository" : "Retest"
+    define_method "test_repository_data_folders#{method_suffix}" do
+      generate_and_assert(
+        xcodeproj_group: Proc.new { |parser| parser.repository_data_group },
+        source_path: "MyProject/GroupWithFolder/Repository",
+        generator_class: RepositoryGenerator,
+        name: name,
+        expected_files: ["Retest/RetestRepositoryImplementation.swift"]
+      )
+    end
   end
 
-  def test_repository_core_folders
-    generate_and_assert(
-      xcodeproj_group: Proc.new { |parser| parser.repository_core_group },
-      source_path: "MyProject/GroupWithFolder/Interactor",
-      generator_class: RepositoryGenerator,
-      name: "Retest",
-      expected_files: ["Retest/RetestRepository.swift"]
-    )
+  [false, true].each do |use_suffix|
+    method_suffix = use_suffix ? "_with_suffix" : ""
+    name = use_suffix ? "RetestRepository" : "Retest"
+    define_method "test_repository_core_folders#{method_suffix}" do
+      generate_and_assert(
+        xcodeproj_group: Proc.new { |parser| parser.repository_core_group },
+        source_path: "MyProject/GroupWithFolder/Interactor",
+        generator_class: RepositoryGenerator,
+        name: name,
+        expected_files: ["Retest/RetestRepository.swift"]
+      )
+    end
   end
 
   private


### PR DESCRIPTION
By default, the generation expects a name without suffix, eg:
```
> ccios -i Login
# Generates LoginInteractor
```

This PR supports a name with already included suffix:
```
> ccios -i LoginInteractor
# Generates LoginInteractor
```

Fix #16 
