### PR TITLE
Release/v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [5.1.0]
+
 ### Changed
 
 - Target variable is now optional, an empty string or an unset value will use the first target of the project. This change allows templates to not overrides global target settings in `.ccios.yml`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccios (5.0.0)
+    ccios (5.1.0)
       activesupport (> 4)
       mustache (~> 1.0)
       xcodeproj (~> 1.4)

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,0 +1,8 @@
+
+## How to release a new version
+
+- Create the release branch `release/vA.B.C`
+- Complete the changelog and add the new vertion title
+- Update the version in ccios.gemspec & run `bundle install`
+- Create a Pull Request
+- Once merged, create a tag `A.B.C` on the merged commit

--- a/ccios.gemspec
+++ b/ccios.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'ccios'
-  s.version     = '5.0.0'
+  s.version     = '5.1.0'
   s.executables << 'ccios'
   s.date        = '2016-08-03'
   s.summary     = "Clean Code iOS Generator"


### PR DESCRIPTION
### Changed

- Target variable is now optional, an empty string or an unset value will use the first target of the project. This change allows templates to not overrides global target settings in `.ccios.yml`
- When multiple targets are provided for a file, `{{project_name}}` will now be replaced by the name of the project instead of the name of the first target
- `@MainActor` has been added to relevent files in Coordinator and Presenter templates to improve Swift 6 support
- dependency provider snippets has been updated to handle Swift 6 issue (see [this issue](https://github.com/Swinject/Swinject/issues/571) for why this is required)